### PR TITLE
Add encoder-safe gate/trigger pulse width option

### DIFF
--- a/src/beat.cpp
+++ b/src/beat.cpp
@@ -1,4 +1,5 @@
 #include "plugin.hpp"
+#include "pulse-width.hpp"
 #include <cmath>
 
 
@@ -133,6 +134,7 @@ struct Beat : Module {
 	// When true, pattern only advances on a BAR pulse (default — most musical
 	// behavior). When false, pattern wrap also advances when BAR isn't patched.
 	bool advanceOnBarOnly = true;
+	int pulseWidthIdx = 0;   // encoder-safe pulse width (index into sfs::PULSE_WIDTHS)
 
 	dsp::SchmittTrigger clockTrigger;
 	dsp::SchmittTrigger barTrigger;
@@ -203,9 +205,10 @@ struct Beat : Module {
 		// Probability check — fires only if random draw is below the set
 		// probability. p=1 always fires, p=0 never fires.
 		if (random::uniform() >= p.probabilities[playStep]) return;
-		gatePulse.trigger(0.001f);
+		const float pw = sfs::pulseWidthSec(pulseWidthIdx);
+		gatePulse.trigger(pw);
 		currentVelocity = clamp(p.velocities[playStep], 0.f, 1.f);
-		if (p.accents[playStep]) accentPulse.trigger(0.001f);
+		if (p.accents[playStep]) accentPulse.trigger(pw);
 	}
 
 	void doReset() {
@@ -320,6 +323,7 @@ struct Beat : Module {
 		json_object_set_new(root, "playStep", json_integer(playStep));
 		json_object_set_new(root, "currentBar", json_integer(currentBar));
 		json_object_set_new(root, "advanceOnBarOnly", json_boolean(advanceOnBarOnly));
+		json_object_set_new(root, "pulseWidthIdx", json_integer(pulseWidthIdx));
 
 		json_t* patArray = json_array();
 		for (int p = 0; p < NUM_PATTERNS; p++) {
@@ -360,6 +364,8 @@ struct Beat : Module {
 			currentBar = clamp((int)json_integer_value(j), 1, MAX_REPEATS);
 		if (json_t* j = json_object_get(root, "advanceOnBarOnly"))
 			advanceOnBarOnly = json_boolean_value(j);
+		if (json_t* j = json_object_get(root, "pulseWidthIdx"))
+			pulseWidthIdx = clamp((int)json_integer_value(j), 0, sfs::NUM_PULSE_WIDTHS - 1);
 
 		json_t* patArray = json_object_get(root, "patterns");
 		if (patArray && json_is_array(patArray)) {
@@ -1262,6 +1268,7 @@ struct BeatWidget : ModuleWidget {
 		menu->addChild(createBoolPtrMenuItem(
 			"Advance only on bar trigger", "",
 			&module->advanceOnBarOnly));
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx);
 
 		menu->addChild(new MenuSeparator);
 		menu->addChild(createMenuLabel("Copy / paste"));

--- a/src/fugue-expander.cpp
+++ b/src/fugue-expander.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include "fugue-messages.hpp"
+#include "pulse-width.hpp"
 
 static const int SLEEP_VALUES[] = {0, 1, 2, 4, 5, 8, 16, 32, 48, 64};
 static const int NUM_SLEEP_VALUES = 10;
@@ -65,6 +66,7 @@ struct FugueX : Module {
 	dsp::SchmittTrigger randSeqButtonTrigger;
 	bool randomizeRequested = false;
 	dsp::PulseGenerator triggerPulses[FUGUE_NUM_VOICES][FUGUE_NUM_STEPS];
+	int pulseWidthIdx = 0;   // encoder-safe pulse width (index into sfs::PULSE_WIDTHS)
 
 	~FugueX() {
 		delete (ExpanderToFugueMessage*)leftExpander.producerMessage;
@@ -202,7 +204,7 @@ struct FugueX : Module {
 			if (hasFugue && fugueState.voices[v].clockRose && fugueState.voices[v].gateOn) {
 				int step = fugueState.voices[v].currentStep;
 				if (step >= 0 && step < FUGUE_NUM_STEPS) {
-					triggerPulses[v][step].trigger(1e-3f);
+					triggerPulses[v][step].trigger(sfs::pulseWidthSec(pulseWidthIdx));
 				}
 			}
 
@@ -250,6 +252,17 @@ struct FugueX : Module {
 				lights[SLEEP_LED_0 + v].setBrightness(0.f);
 			}
 		}
+	}
+
+	json_t* dataToJson() override {
+		json_t* rootJ = json_object();
+		json_object_set_new(rootJ, "pulseWidthIdx", json_integer(pulseWidthIdx));
+		return rootJ;
+	}
+
+	void dataFromJson(json_t* rootJ) override {
+		json_t* pwJ = json_object_get(rootJ, "pulseWidthIdx");
+		if (pwJ) pulseWidthIdx = clamp((int)json_integer_value(pwJ), 0, sfs::NUM_PULSE_WIDTHS - 1);
 	}
 };
 
@@ -363,6 +376,14 @@ struct FugueXWidget : ModuleWidget {
 			addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(x, gateBY)), module, FugueX::GATE_B_OUTPUT_0 + s));
 			addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(x, gateCY)), module, FugueX::GATE_C_OUTPUT_0 + s));
 		}
+	}
+
+	void appendContextMenu(Menu* menu) override {
+		FugueX* module = dynamic_cast<FugueX*>(this->module);
+		if (!module) return;
+		menu->addChild(new MenuSeparator);
+		menu->addChild(createMenuLabel("Outputs"));
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx);
 	}
 };
 

--- a/src/fugue.cpp
+++ b/src/fugue.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include "scales.hpp"
+#include "pulse-width.hpp"
 
 // ─── Scale Tables ────────────────────────────────────────────────────────────
 // Scales come from the shared canonical list (src/scales.hpp) so SCALE CV values
@@ -193,6 +194,7 @@ struct Fugue : Module {
 	// the gate just mirrored the clock's high time, so a trigger clock produced
 	// trigger-width "gates"; this makes a proper musical gate.
 	float gateLength = 0.5f;
+	int pulseWidthIdx = 0;   // encoder-safe trigger-mode gate width (index into sfs::PULSE_WIDTHS)
 
 	// ─── Constructor ─────────────────────────────────────────────────────────
 
@@ -274,6 +276,7 @@ struct Fugue : Module {
 		json_object_set_new(rootJ, "faderRange", json_real(faderRangeVolts));
 		json_object_set_new(rootJ, "harmonicLock", json_boolean(harmonicLock));
 		json_object_set_new(rootJ, "gateLength", json_real(gateLength));
+		json_object_set_new(rootJ, "pulseWidthIdx", json_integer(pulseWidthIdx));
 		// Marks this patch as using the canonical shared scale order. Its ABSENCE on
 		// load means the patch predates the migration and its SCALE_PARAM index must
 		// be remapped from Fugue's old private order (see dataFromJson).
@@ -288,6 +291,8 @@ struct Fugue : Module {
 		if (hlJ) harmonicLock = json_boolean_value(hlJ);
 		json_t* glJ = json_object_get(rootJ, "gateLength");
 		if (glJ) gateLength = json_number_value(glJ);
+		json_t* pwJ = json_object_get(rootJ, "pulseWidthIdx");
+		if (pwJ) pulseWidthIdx = clamp((int)json_integer_value(pwJ), 0, sfs::NUM_PULSE_WIDTHS - 1);
 
 		// Patch migration: params are already loaded by the base class before this
 		// runs, so params[SCALE_PARAM] holds the saved index. A pre-canonical patch
@@ -654,7 +659,7 @@ struct Fugue : Module {
 				if (gateTriggerMode) {
 					int ti = v * NUM_STEPS + voice.currentStep;
 					if (params[GATE_TOGGLE_PARAM_0 + ti].getValue() > 0.5f)
-						voice.gatePulse.trigger(0.001f);
+						voice.gatePulse.trigger(sfs::pulseWidthSec(pulseWidthIdx));
 				}
 			}
 
@@ -919,6 +924,9 @@ struct FugueWidget : ModuleWidget {
 				[=]() { return std::fabs(module->gateLength - gv) < 1e-4f; },
 				[=]() { module->gateLength = gv; }));
 		}
+		// Trigger-mode gate width (encoder-safe). Only affects the "Trigger" gate
+		// length; duty-cycle gates already stretch across the step.
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx, "Trigger width");
 
 		menu->addChild(new MenuSeparator);
 		menu->addChild(createMenuItem("Randomize Sequence", "",

--- a/src/metafugue.cpp
+++ b/src/metafugue.cpp
@@ -916,7 +916,7 @@ struct MetaFugue : Module {
 			if (clockRose && stepFires) {
 				int step = voice.currentStep;
 				if (step >= 0 && step < NUM_STEPS) {
-					triggerPulses[v][step].trigger(1e-3f);
+					triggerPulses[v][step].trigger(sfs::pulseWidthSec(pulseWidthIdx));
 				}
 			}
 			int gateBase = (v == 0) ? GATE_A_STEP_OUTPUT_0

--- a/src/metafugue.cpp
+++ b/src/metafugue.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include "scales.hpp"
+#include "pulse-width.hpp"
 
 // ─── Scale Tables ────────────────────────────────────────────────────────────
 // Scales come from the shared canonical list (src/scales.hpp) so SCALE CV
@@ -239,6 +240,7 @@ struct MetaFugue : Module {
 	// Previously the gate mirrored the clock's high time, so a trigger clock
 	// produced trigger-width gates.
 	float gateLength = 0.5f;
+	int pulseWidthIdx = 0;   // encoder-safe trigger-mode gate width (index into sfs::PULSE_WIDTHS)
 
 	// ─── Expander state ─────────────────────────────────────────────────────
 	int sleepCounter[NUM_VOICES] = {};       // clocks remaining in sleep
@@ -377,6 +379,7 @@ struct MetaFugue : Module {
 		json_object_set_new(rootJ, "faderRange", json_real(faderRangeVolts));
 		json_object_set_new(rootJ, "harmonicLock", json_boolean(harmonicLock));
 		json_object_set_new(rootJ, "gateLength", json_real(gateLength));
+		json_object_set_new(rootJ, "pulseWidthIdx", json_integer(pulseWidthIdx));
 		// Bump on any change to SCALE ordering so dataFromJson can migrate
 		// older saved scaleParam values.
 		json_object_set_new(rootJ, "schemaVersion", json_integer(2));
@@ -390,6 +393,8 @@ struct MetaFugue : Module {
 		if (hlJ) harmonicLock = json_boolean_value(hlJ);
 		json_t* glJ = json_object_get(rootJ, "gateLength");
 		if (glJ) gateLength = json_number_value(glJ);
+		json_t* pwJ = json_object_get(rootJ, "pulseWidthIdx");
+		if (pwJ) pulseWidthIdx = clamp((int)json_integer_value(pwJ), 0, sfs::NUM_PULSE_WIDTHS - 1);
 
 		// Schema v1 → v2: SCALE ordering changed to match Note. Remap the
 		// saved scale param so the patch sounds the same as before.
@@ -894,7 +899,7 @@ struct MetaFugue : Module {
 			bool toggleOn = params[GATE_TOGGLE_PARAM_0 + toggleIdx].getValue() > 0.5f;
 			bool stepFires = toggleOn && !sleeping[v] && !probGateSuppress[v];
 			if (clockRose && stepFires && gateTriggerMode)
-				voice.gatePulse.trigger(0.001f);
+				voice.gatePulse.trigger(sfs::pulseWidthSec(pulseWidthIdx));
 			bool gateHi;
 			if (gatePassthrough)
 				gateHi = stepFires && voice.clockHigh;          // old clock-follow behavior
@@ -1315,6 +1320,9 @@ struct MetaFugueWidget : ModuleWidget {
 				[=]() { return std::fabs(module->gateLength - gv) < 1e-4f; },
 				[=]() { module->gateLength = gv; }));
 		}
+		// Trigger-mode gate width (encoder-safe). Only affects the "Trigger" gate
+		// length; duty-cycle gates already stretch across the step.
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx, "Trigger width");
 
 		menu->addChild(new MenuSeparator);
 		menu->addChild(createMenuItem("Randomize Sequence", "",

--- a/src/meter.cpp
+++ b/src/meter.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include "meter-messages.hpp"
+#include "pulse-width.hpp"
 #include <cmath>
 
 
@@ -133,6 +134,9 @@ struct Meter : Module {
 
 	// --- Run state ---
 	bool running = true;
+
+	// --- Encoder-safe pulse width (index into sfs::PULSE_WIDTHS) ---
+	int pulseWidthIdx = 0;   // 0 == 1 ms (legacy default)
 
 	// --- External clock measurement ---
 	int samplesSinceLastExtPulse = 0;
@@ -325,7 +329,7 @@ struct Meter : Module {
 		// here would inject an extra CLOCK into modules clocked from a grid
 		// output without a Reset cable.
 		for (int i = 0; i < NUM_OUTPUTS; i++) {
-			pulses[i].trigger(0.001f);
+			pulses[i].trigger(sfs::pulseWidthSec(pulseWidthIdx));
 		}
 		displayedSixteenth = 0;
 		barsSinceReset = 0;
@@ -378,7 +382,7 @@ struct Meter : Module {
 			&& resetInputTrigger.process(inputs[RESET_INPUT].getVoltage());
 		if (resetBtn || resetIn) {
 			doReset();
-			resetOutPulse.trigger(0.001f);
+			resetOutPulse.trigger(sfs::pulseWidthSec(pulseWidthIdx));
 		}
 
 		// --- Read CV-modulated parameters ---
@@ -545,7 +549,7 @@ struct Meter : Module {
 		for (int i = 0; i < 5; i++) {
 			if (samplesSinceGrid[i] >= gridBase[i]) {
 				samplesSinceGrid[i] -= gridBase[i];
-				pulses_grid[i].trigger(0.001f);
+				pulses_grid[i].trigger(sfs::pulseWidthSec(pulseWidthIdx));
 			}
 		}
 
@@ -563,7 +567,7 @@ struct Meter : Module {
 
 		// Helper to fire a pulse and update its flash state
 		auto firePulse = [&](int outIdx) {
-			pulses[outIdx].trigger(0.001f);
+			pulses[outIdx].trigger(sfs::pulseWidthSec(pulseWidthIdx));
 			if (outIdx == SUB_BAR) msgBar = true;   // notify the expander
 			pulseFlashIdx[outIdx] = pulseInBar[outIdx];
 			pulseInBar[outIdx]++;
@@ -644,7 +648,7 @@ struct Meter : Module {
 				// the downbeat straight pulses, mirroring the swung set).
 				for (int i = 0; i < 5; i++) {
 					samplesSinceGrid[i] = 0.f;
-					pulses_grid[i].trigger(0.001f);
+					pulses_grid[i].trigger(sfs::pulseWidthSec(pulseWidthIdx));
 				}
 				// Commit pending swing → active for the new bar. Doing it
 				// only on bar boundaries prevents mid-period accumulator
@@ -686,6 +690,7 @@ struct Meter : Module {
 		json_object_set_new(rootJ, "resetOnPlay", json_boolean(resetOnPlay));
 		json_object_set_new(rootJ, "bpmCvAbsolute", json_boolean(bpmCvAbsolute));
 		json_object_set_new(rootJ, "barsSinceReset", json_integer(barsSinceReset));
+		json_object_set_new(rootJ, "pulseWidthIdx", json_integer(pulseWidthIdx));
 		return rootJ;
 	}
 
@@ -702,6 +707,8 @@ struct Meter : Module {
 		if (bcaJ) bpmCvAbsolute = json_boolean_value(bcaJ);
 		json_t* bsrJ = json_object_get(rootJ, "barsSinceReset");
 		if (bsrJ) barsSinceReset = (int)json_integer_value(bsrJ);
+		json_t* pwJ = json_object_get(rootJ, "pulseWidthIdx");
+		if (pwJ) pulseWidthIdx = clamp((int)json_integer_value(pwJ), 0, sfs::NUM_PULSE_WIDTHS - 1);
 	}
 };
 
@@ -1133,6 +1140,10 @@ struct MeterWidget : ModuleWidget {
 		menu->addChild(createBoolPtrMenuItem(
 			"BPM CV absolute (0.01V/BPM — for Arrange)", "",
 			&module->bpmCvAbsolute));
+
+		menu->addChild(new MenuSeparator);
+		menu->addChild(createMenuLabel("Outputs"));
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx);
 
 		if (module->extClockConnected && module->extClockHasMeasurement) {
 			menu->addChild(new MenuSeparator);

--- a/src/meterx.cpp
+++ b/src/meterx.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include "meter-messages.hpp"
+#include "pulse-width.hpp"
 #include <cmath>
 
 // ─── Meter X — clock/bar expander for Meter ──────────────────────────────────
@@ -26,6 +27,7 @@ struct MeterX : Module {
 	dsp::PulseGenerator ppqnPulse, barPulse[8];
 	float flash[10] = {};          // LED flash: [0]=ppqn, [1]=run(unused), [2..9]=bars
 	float barPos = 0.f;            // continuous bars-since-reset (drives the cycle pies)
+	int pulseWidthIdx = 0;         // encoder-safe pulse width (index into sfs::PULSE_WIDTHS)
 
 	MeterX() {
 		config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
@@ -50,18 +52,30 @@ struct MeterX : Module {
 		lights[RUN_LIGHT].setBrightness(msg.running ? 1.f : 0.f);
 
 		// 24 PPQN
-		if (msg.ppqn24) { ppqnPulse.trigger(0.001f); flash[0] = 1.f; }
+		const float pw = sfs::pulseWidthSec(pulseWidthIdx);
+		if (msg.ppqn24) { ppqnPulse.trigger(pw); flash[0] = 1.f; }
 		outputs[PPQN24_OUTPUT].setVoltage(ppqnPulse.process(dt) ? 10.f : 0.f);
 		flash[0] = std::max(0.f, flash[0] - decay);
 		lights[PPQN24_LIGHT].setBrightness(flash[0]);
 
 		// Bar divisions
 		for (int k = 0; k < 8; k++) {
-			if (msg.bar[k]) { barPulse[k].trigger(0.001f); flash[2 + k] = 1.f; }
+			if (msg.bar[k]) { barPulse[k].trigger(pw); flash[2 + k] = 1.f; }
 			outputs[BAR_OUTPUT + k].setVoltage(barPulse[k].process(dt) ? 10.f : 0.f);
 			flash[2 + k] = std::max(0.f, flash[2 + k] - decay);
 			lights[BAR_LIGHT + k].setBrightness(flash[2 + k]);
 		}
+	}
+
+	json_t* dataToJson() override {
+		json_t* rootJ = json_object();
+		json_object_set_new(rootJ, "pulseWidthIdx", json_integer(pulseWidthIdx));
+		return rootJ;
+	}
+
+	void dataFromJson(json_t* rootJ) override {
+		json_t* pwJ = json_object_get(rootJ, "pulseWidthIdx");
+		if (pwJ) pulseWidthIdx = clamp((int)json_integer_value(pwJ), 0, sfs::NUM_PULSE_WIDTHS - 1);
 	}
 };
 
@@ -126,6 +140,14 @@ struct MeterXWidget : ModuleWidget {
 			addOutput(createOutputCentered<PJ301MPort>(mm2px(Vec(MX_X_JACK, ys[2 + k])), module, MeterX::BAR_OUTPUT + k));
 			addChild(createLightCentered<SmallLight<YellowLight>>(mm2px(Vec(MX_X_LED, ys[2 + k])), module, MeterX::BAR_LIGHT + k));
 		}
+	}
+
+	void appendContextMenu(Menu* menu) override {
+		MeterX* module = dynamic_cast<MeterX*>(this->module);
+		if (!module) return;
+		menu->addChild(new MenuSeparator);
+		menu->addChild(createMenuLabel("Outputs"));
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx);
 	}
 };
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1,5 +1,6 @@
 #include "plugin.hpp"
 #include "scales.hpp"
+#include "pulse-width.hpp"
 #include <cmath>
 
 
@@ -152,6 +153,7 @@ struct Note : Module {
 	// The step interval is measured from the time between successive step
 	// advances, so the gate tracks tempo automatically.
 	float gateLength = 0.5f;
+	int   pulseWidthIdx = 0;           // encoder-safe trigger/accent width (index into sfs::PULSE_WIDTHS)
 	int   stepIntervalSamples = 0;     // measured time between step advances
 	int   samplesSinceAdvance = 0;
 	int   gateRemaining = 0;           // samples of gate left to hold
@@ -272,7 +274,7 @@ struct Note : Module {
 		// with a gap before the next note.
 		auto holdGate = [&]() {
 			float frac = nextTie ? 1.0f : gateLength;
-			if (frac <= 0.f) { gatePulse.trigger(0.001f); return; }   // trigger mode
+			if (frac <= 0.f) { gatePulse.trigger(sfs::pulseWidthSec(pulseWidthIdx)); return; }   // trigger mode
 			gateRemaining = std::max(1, (int)(frac * ivl));
 		};
 
@@ -293,7 +295,7 @@ struct Note : Module {
 		currentVelocity = clamp(p.velocities[playStep], 0.f, 1.f);
 		currentVoct = voctForRow(pitch);
 		noteSounding = true;
-		if (p.accents[playStep]) accentPulse.trigger(0.001f);
+		if (p.accents[playStep]) accentPulse.trigger(sfs::pulseWidthSec(pulseWidthIdx));
 		holdGate();
 	}
 
@@ -438,6 +440,7 @@ struct Note : Module {
 		json_object_set_new(root, "octaveShift", json_integer(octaveShift));
 		json_object_set_new(root, "advanceOnBarOnly", json_boolean(advanceOnBarOnly));
 		json_object_set_new(root, "gateLength", json_real(gateLength));
+		json_object_set_new(root, "pulseWidthIdx", json_integer(pulseWidthIdx));
 
 		json_t* patArray = json_array();
 		for (int p = 0; p < N_PATTERNS; p++) {
@@ -489,6 +492,8 @@ struct Note : Module {
 			advanceOnBarOnly = json_boolean_value(j);
 		if (json_t* j = json_object_get(root, "gateLength"))
 			gateLength = (float)json_real_value(j);
+		if (json_t* j = json_object_get(root, "pulseWidthIdx"))
+			pulseWidthIdx = clamp((int)json_integer_value(j), 0, sfs::NUM_PULSE_WIDTHS - 1);
 
 		json_t* patArray = json_object_get(root, "patterns");
 		if (patArray && json_is_array(patArray)) {
@@ -1523,6 +1528,10 @@ struct NoteWidget : ModuleWidget {
 				[=]() { return std::fabs(module->gateLength - v) < 1e-4f; },
 				[=]() { module->gateLength = v; }));
 		}
+		// Trigger-mode gate + accent pulse width (encoder-safe). Only affects the
+		// 1ms trigger path (gate length "Trigger") and the accent output; held
+		// gates already stretch across the step.
+		sfs::addPulseWidthMenu(menu, &module->pulseWidthIdx, "Trigger/accent width");
 
 		menu->addChild(new MenuSeparator);
 		menu->addChild(createMenuLabel("Patterns"));

--- a/src/pulse-width.hpp
+++ b/src/pulse-width.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include "plugin.hpp"
+
+// Shared "encoder-safe" gate/trigger pulse width.
+//
+// Direct ES-9 outputs are full-sample-rate DAC channels, so the default 1 ms
+// trigger is tens of samples wide and always lands cleanly. The Expert Sleepers
+// Encoders (8CV / 8GT / ES-5) time-multiplex 8 channels down one connection, so
+// each channel is effectively resampled to ~2-16 kHz depending on how many are
+// active. A 1 ms pulse can be only ~2 frames wide there -- jittered, halved, or
+// dropped outright. Widening the pulse to 3-5 ms makes clocks/gates survive that
+// path (and gives a companion V/oct channel time to settle before the gate is
+// sampled).
+//
+// The index is stored (not the raw float) so patches stay stable and the menu
+// can render a radio selection. Default index 0 == 1 ms, i.e. unchanged from
+// legacy behaviour for existing patches that never touch the setting.
+namespace sfs {
+
+static const int   NUM_PULSE_WIDTHS = 4;
+static const float PULSE_WIDTHS[NUM_PULSE_WIDTHS]       = { 0.001f, 0.002f, 0.005f, 0.010f };
+static const char* PULSE_WIDTH_LABELS[NUM_PULSE_WIDTHS] = {
+	"1 ms (default)", "2 ms", "5 ms (encoder-safe)", "10 ms" };
+
+// Clamp a stored index and return the pulse width in seconds.
+inline float pulseWidthSec(int idx) {
+	if (idx < 0 || idx >= NUM_PULSE_WIDTHS) idx = 0;
+	return PULSE_WIDTHS[idx];
+}
+
+// Append a "Gate/trigger width" submenu that reads/writes *idxPtr. The current
+// choice shows as the submenu's right-hand text.
+inline void addPulseWidthMenu(Menu* menu, int* idxPtr,
+                              const char* label = "Gate/trigger width") {
+	int cur = (*idxPtr >= 0 && *idxPtr < NUM_PULSE_WIDTHS) ? *idxPtr : 0;
+	menu->addChild(createSubmenuItem(label, PULSE_WIDTH_LABELS[cur],
+		[idxPtr](Menu* sub) {
+			for (int i = 0; i < NUM_PULSE_WIDTHS; i++) {
+				sub->addChild(createCheckMenuItem(PULSE_WIDTH_LABELS[i], "",
+					[idxPtr, i]() { return *idxPtr == i; },
+					[idxPtr, i]() { *idxPtr = i; }));
+			}
+		}));
+}
+
+} // namespace sfs


### PR DESCRIPTION
## Why

Clock/sequencer trigger, gate, and accent outputs fire a fixed **1 ms** pulse. Direct to an ES-9 those are full-sample-rate DAC channels, so a 1 ms pulse is tens of samples wide and always lands cleanly. The Expert Sleepers **Encoders** (8CV / 8GT / ES-5) time-multiplex 8 channels down one connection, so each channel is effectively resampled to **~2–16 kHz** depending on how many are active. At the low end a 1 ms pulse is only ~2 frames wide and gets **jittered, halved, or dropped** — sloppy/missed clocks and gates downstream, and wrong-pitch attack blips when a gate lands before its companion V/oct channel has settled.

This came up debugging modules that work well straight into an ES-9 but poorly through the Encoders' multiplexed CV/gate path.

## What

A per-module **"Gate/trigger width"** context-menu option so pulses can be widened to survive the multiplexed path.

- New shared helper **`src/pulse-width.hpp`** — width table (**1 / 2 / 5 / 10 ms**, default 1 ms = unchanged) plus `pulseWidthSec()` and a reusable `addPulseWidthMenu()`.
- Applied to **Meter, Meter X, Beat, Note, Fugue, MetaFugue**. Every fixed-1 ms output pulse (subdivisions, reset out, grid outs, 24 PPQN + bar triggers, gates, accents, trigger-mode gates) now reads the selected width.
- The width index is persisted in each module's JSON. Meter X previously had no JSON/menu — both added.
- Menu labels are tailored: Meter/Meter X under an "Outputs" header; Note shows "Trigger/accent width"; Fugue/MetaFugue show "Trigger width" (their duty-cycle gates already stretch across the step, so only the trigger path is affected).

## Behaviour / compatibility

- **Default is index 0 = 1 ms**, so existing patches and the direct-to-ES-9 workflow are unchanged.
- **Recommended for an ES/Encoders rig: 5 ms** — safe across the full 30–300 BPM range for every subdivision.
- **Caveat:** 10 ms exceeds the period of Meter X's 24 PPQN output above ~200 BPM (would hold the gate continuously). 5 ms is safe everywhere; 10 ms is intended for slow clocks only.

## Scope notes

- **Chance was intentionally left alone** — its gate is already a level gate (tens of ms), not a 1 ms pulse. Its CV/oct trouble through the encoder is the GLIDE continuously-moving CV and pitch/gate slot-skew, which is a patching choice (GLIDE → 0 into an encoder) plus the general slot-skew that widening the *upstream* clock helps with.
- **Vac and Record** also emit 1 ms triggers but aren't typical encoder feeds (Record's gate drives the device-under-test with latency calibration), so they were left out.

## Testing

No Rack SDK was reachable in the working environment (network policy blocks `vcvrack.com`; CI only builds on `master`), so a full plugin build wasn't run here. The new header was compile-checked against a stub of the Rack menu API under `-std=c++11 -Wall -Wextra` (matching the repo's mingw strictness) — clean. The `.cpp` edits are one-token trigger swaps plus JSON/menu code mirroring each file's existing patterns. **A local `make` is recommended before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185GBSXVuMnhd9qQziyhBdW

---
_Generated by [Claude Code](https://claude.ai/code/session_0185GBSXVuMnhd9qQziyhBdW)_